### PR TITLE
Keep most recently used typeface open

### DIFF
--- a/Driver/Font/TrueType/Adapter/ttadapter.c
+++ b/Driver/Font/TrueType/Adapter/ttadapter.c
@@ -1,0 +1,153 @@
+/***********************************************************************
+ *
+ *	Copyright FreeGEOS-Project
+ *
+ * PROJECT:	  FreeGEOS
+ * MODULE:	  TrueType font driver
+ * FILE:	  ttadapter.c
+ *
+ * AUTHOR:	  Marcus Groeber: July 16 2023
+ *
+ * REVISION HISTORY:
+ *	Date	  Name	    Description
+ *	----	  ----	    -----------
+ *	16/07/23  MG	    Initial version
+ *
+ * DESCRIPTION:
+ *	Common functions used by TrueType Adapter.
+ ***********************************************************************/
+
+#include "ttadapter.h"
+#include <ec.h>
+#include <geode.h>
+
+static int strcmp( const char* s1, const char* s2 );
+
+
+/********************************************************************
+ *                      TrueType_Lock_Face
+ ********************************************************************
+ * SYNOPSIS:	  Active a particular face.
+ * 
+ * PARAMETERS:    *trueTypeVars        
+ *                *entry                Ptr to font entry.
+ * 
+ * RETURNS:       TT_Error
+ * 
+ * STRATEGY:      - check if face is already loaded
+ *                - if not, open file with face
+ *                - load face from file
+ * 
+ * REVISION HISTORY:
+ *      Date      Name      Description
+ *      ----      ----      -----------
+ *      16/07/23  MG        Initial Revision
+ * 
+ *******************************************************************/
+
+Boolean TrueType_Lock_Face(TRUETYPE_VARS, TrueTypeOutlineEntry* entry)
+{
+        Boolean failure = TRUE;
+
+        if( strcmp( entry->TTOE_fontFileName, trueTypeVars->entry.TTOE_fontFileName )==0 )
+        {
+            failure = FALSE;
+            goto Fin;
+        }
+        
+        TrueType_Free_Face( trueTypeVars );
+
+        FilePushDir();
+        FileSetCurrentPath( SP_FONT, TTF_DIRECTORY );
+
+        /* get filename and load ttf file */
+        TTFILE = FileOpen( entry->TTOE_fontFileName, FILE_ACCESS_R | FILE_DENY_W );       
+        /* change owner to ourselves, to make handle persist if application closes */
+        HandleModifyOwner( (MemHandle)TTFILE, GeodeGetCodeProcessHandle() );
+        FilePopDir();
+
+        if( TT_Open_Face( TTFILE, &FACE ) )
+                goto Fin;
+        if ( TT_Get_Face_Properties( FACE, &FACE_PROPERTIES ) )
+                goto Fail;
+        if ( getCharMap( trueTypeVars, &CHAR_MAP ) )
+                goto Fail;
+
+        /* font has been fully loaded */
+        trueTypeVars->entry = *entry;
+        failure = FALSE;
+Fin:
+        return failure;
+Fail:
+        TT_Close_Face( FACE );
+        goto Fin;
+}
+
+
+/********************************************************************
+ *                      TrueType_Unlock_Face
+ ********************************************************************
+ * SYNOPSIS:	  Deactivate the currently active face.
+ * 
+ * PARAMETERS:    *trueTypeVars        
+ * 
+ * RETURNS:       TT_Error
+ * 
+ * STRATEGY:      - free resources used by face
+ *                - close file
+ * 
+ * REVISION HISTORY:
+ *      Date      Name      Description
+ *      ----      ----      -----------
+ *      16/07/23  MG        Initial Revision
+ * 
+ *******************************************************************/
+
+void TrueType_Unlock_Face(TRUETYPE_VARS)
+{
+        /* Will be used for unlocking moveable font resources */
+        (void)trueTypeVars;
+}
+
+/********************************************************************
+ *                      TrueType_Free_Face
+ ********************************************************************
+ * SYNOPSIS:	  Close the currently active face.
+ * 
+ * PARAMETERS:    *trueTypeVars        
+ * 
+ * RETURNS:       TT_Error
+ * 
+ * STRATEGY:      - free resources used by face
+ *                - close file
+ * 
+ * REVISION HISTORY:
+ *      Date      Name      Description
+ *      ----      ----      -----------
+ *      16/07/23  MG        Initial Revision
+ * 
+ *******************************************************************/
+
+void TrueType_Free_Face(TRUETYPE_VARS)
+{
+        if ( trueTypeVars->entry.TTOE_fontFileName[0] )
+        {
+            TT_Close_Face( FACE );
+            trueTypeVars->entry.TTOE_fontFileName[0] = 0;
+        }
+        if ( TTFILE )
+        {
+            FileClose( TTFILE, FALSE );
+            TTFILE = NullHandle;
+        }
+}
+
+static int strcmp( const char* s1, const char* s2 )
+{
+        while ( *s1 && ( *s1 == *s2 ) )
+        {
+                s1++;
+                s2++;
+        }
+        return *(const unsigned char*)s1 - *(const unsigned char*)s2;
+}

--- a/Driver/Font/TrueType/Adapter/ttadapter.h
+++ b/Driver/Font/TrueType/Adapter/ttadapter.h
@@ -375,6 +375,10 @@ typedef struct
     TT_CharMap                  charMap;
     TT_Outline                  outline;
     TT_BBox                     bbox;
+
+    /* currently open face */
+    FileHandle                  ttfile;
+    TrueTypeOutlineEntry        entry;
 } TrueTypeVars;
 
 
@@ -393,7 +397,8 @@ typedef struct
 #define GLYPH_BBOX              trueTypeVars->glyphMetrics.bbox
 #define RASTER_MAP              trueTypeVars->rasterMap
 #define SCALE_HEIGHT            trueTypeVars->scaleHeight
-#define SCALE_WIDTH             trueTypeVars->scaleWidth   
+#define SCALE_WIDTH             trueTypeVars->scaleWidth
+#define TTFILE                  trueTypeVars->ttfile
 
 #define UNITS_PER_EM            FACE_PROPERTIES.header->Units_Per_EM
 
@@ -462,5 +467,13 @@ typedef struct
 #define WBFIXED_TO_WWFIXEDASDWORD( value )       \
         ( ( (long)value.WBF_int << 16 ) | ( value.WBF_frac << 8 ) )
 
+
+/***********************************************************************
+ *      functions
+ ***********************************************************************/
+
+Boolean TrueType_Lock_Face(TRUETYPE_VARS, TrueTypeOutlineEntry* entry);
+void TrueType_Unlock_Face(TRUETYPE_VARS);
+void TrueType_Free_Face(TRUETYPE_VARS);
 
 #endif /* _TTADAPTER_H_ */

--- a/Driver/Font/TrueType/Adapter/ttadapter.h
+++ b/Driver/Font/TrueType/Adapter/ttadapter.h
@@ -378,6 +378,10 @@ typedef struct
     TT_CharMap                  charMap;
     TT_Outline                  outline;
     TT_BBox                     bbox;
+
+    /* currently open face */
+    FileHandle                  ttfile;
+    TrueTypeOutlineEntry        entry;
 } TrueTypeVars;
 
 
@@ -396,7 +400,8 @@ typedef struct
 #define GLYPH_BBOX              trueTypeVars->glyphMetrics.bbox
 #define RASTER_MAP              trueTypeVars->rasterMap
 #define SCALE_HEIGHT            trueTypeVars->scaleHeight
-#define SCALE_WIDTH             trueTypeVars->scaleWidth   
+#define SCALE_WIDTH             trueTypeVars->scaleWidth
+#define TTFILE                  trueTypeVars->ttfile
 
 #define UNITS_PER_EM            FACE_PROPERTIES.header->Units_Per_EM
 
@@ -462,5 +467,13 @@ typedef struct
 #define WBFIXED_TO_WWFIXEDASDWORD( value )       \
         ( (long) ( ( (long)(value.WBF_int) ) * 0x00010000 ) | ( ( (long)value.WBF_frac) << 8 ) )
 
+
+/***********************************************************************
+ *      functions
+ ***********************************************************************/
+
+Boolean TrueType_Lock_Face(TRUETYPE_VARS, TrueTypeOutlineEntry* entry);
+void TrueType_Unlock_Face(TRUETYPE_VARS);
+void TrueType_Free_Face(TRUETYPE_VARS);
 
 #endif /* _TTADAPTER_H_ */

--- a/Driver/Font/TrueType/Adapter/ttcharmapper.c
+++ b/Driver/Font/TrueType/Adapter/ttcharmapper.c
@@ -281,27 +281,26 @@ CharMapFlags GeosCharMapFlag( word geosChar )
 /*
  * Get microsoft unicode charmap in face.
  */
-TT_Error getCharMap( TT_Face face, TT_CharMap* charMap )
+TT_Error getCharMap( TRUETYPE_VARS, TT_CharMap* charMap )
 {
-        TT_Face_Properties  face_Properties;
         TT_UShort           platform;
         TT_UShort           encoding;
         int                 map;
 
 
-        TT_Get_Face_Properties( face, &face_Properties );
+        TT_Get_Face_Properties( FACE, &FACE_PROPERTIES );
 
-	for ( map = 0; map < face_Properties.num_CharMaps; ++map ) 
+	for ( map = 0; map < FACE_PROPERTIES.num_CharMaps; ++map ) 
         {
-		TT_Get_CharMap_ID( face, map, &platform, &encoding );
+		TT_Get_CharMap_ID( FACE, map, &platform, &encoding );
 		if ( platform == TT_PLATFORM_MICROSOFT && encoding == TT_MS_ID_UNICODE_CS )
                 {
-		        TT_Get_CharMap(face, map, charMap);
+		        TT_Get_CharMap(FACE, map, charMap);
 			break;
 		}
 	}
 
-        if ( map == face_Properties.num_CharMaps ) return TT_Err_CMap_Table_Missing;
+        if ( map == FACE_PROPERTIES.num_CharMaps ) return TT_Err_CMap_Table_Missing;
         else                                       return TT_Err_Ok;
 }
 

--- a/Driver/Font/TrueType/Adapter/ttcharmapper.h
+++ b/Driver/Font/TrueType/Adapter/ttcharmapper.h
@@ -22,6 +22,7 @@
 
 #include <geos.h>
 #include <freetype.h>
+#include "ttadapter.h"
 
 
 typedef ByteFlags CharMapFlags;
@@ -46,11 +47,13 @@ typedef struct
  *      internal functions
  ***********************************************************************/
 
+word GeosCharToUnicode( word geosChar );
+
 word InitGeosCharsInCharMap( TT_CharMap map, char* firstChar, char* lastChar );
 
 word CountKernPairsWithGeosChars( TT_Face face );
 
-TT_Error getCharMap( TT_Face face, TT_CharMap* charMap );
+TT_Error getCharMap( TRUETYPE_VARS, TT_CharMap* charMap );
 
 CharMapFlags GeosCharMapFlag( word geosChar );
 

--- a/Driver/Font/TrueType/Adapter/ttchars.c
+++ b/Driver/Font/TrueType/Adapter/ttchars.c
@@ -71,7 +71,6 @@ void _pascal TrueType_Gen_Chars(
                         MemHandle            bitmapHandle,
                         MemHandle            varBlock ) 
 {
-        FileHandle             truetypeFile;
         MemHandle              fontBufHandle;
         TrueTypeOutlineEntry*  trueTypeOutline;
         TT_UShort              charIndex;
@@ -89,24 +88,12 @@ EC(     ECCheckMemHandle( varBlock ) );
 
         /* get trueTypeVar block */
         trueTypeVars = MemLock( varBlock );
-        if( trueTypeVars == NULL )
-        {
-                MemReAlloc( varBlock, sizeof( TrueTypeVars ), HAF_NO_ERR );
-                trueTypeVars = MemLock( varBlock );
-        }
+EC(     ECCheckBounds( (void*)trueTypeVars ) );
 
-
-        FilePushDir();
-        FileSetCurrentPath( SP_FONT, TTF_DIRECTORY );
-
-        // get filename an load ttf file 
         trueTypeOutline = LMemDerefHandles( MemPtrToHandle( (void*)fontInfo ), outlineEntry->OE_handle );
-        truetypeFile = FileOpen( trueTypeOutline->TTOE_fontFileName, FILE_ACCESS_R | FILE_DENY_W );
-        
-EC(     ECCheckFileHandle( truetypeFile ) );
 
         /* open face, create instance and glyph */
-        if( TT_Open_Face( truetypeFile, &FACE ) )
+        if( TrueType_Lock_Face(trueTypeVars, trueTypeOutline) )
                 goto Fail;
 
         TT_New_Glyph( FACE, &GLYPH );
@@ -114,7 +101,6 @@ EC(     ECCheckFileHandle( truetypeFile ) );
         TT_Set_Instance_Resolutions( INSTANCE, 72, 72 );
 
          /* get TT char index */
-        getCharMap( FACE, &CHAR_MAP );
         charIndex = TT_Char_Index( CHAR_MAP, GeosCharToUnicode( character ) );
 
         /* set pointsize and get metrics */
@@ -221,10 +207,8 @@ EC(     ECCheckFileHandle( truetypeFile ) );
 
         /* cleanup */
         MemUnlock( bitmapHandle );
+        TrueType_Unlock_Face( trueTypeVars );
 Fail:
-        TT_Close_Face( FACE );
-        FileClose( truetypeFile, FALSE );
-        FilePopDir(); 
         MemUnlock( varBlock );
 }
 

--- a/Driver/Font/TrueType/Adapter/ttinit.c
+++ b/Driver/Font/TrueType/Adapter/ttinit.c
@@ -164,7 +164,7 @@ void _pascal TrueType_InitFonts( MemHandle fontInfoBlock, MemHandle varBlock )
         trueTypeVars = MemLock( varBlock );
         if( trueTypeVars == NULL )
         {
-                MemReAlloc( varBlock, sizeof( TrueTypeVars ), HAF_NO_ERR );
+                MemReAlloc( varBlock, sizeof( TrueTypeVars ), HAF_NO_ERR | HAF_ZERO_INIT );
                 trueTypeVars = MemLock( varBlock );
         }
 
@@ -281,7 +281,7 @@ static void ProcessFont( TRUETYPE_VARS, const char* fileName, MemHandle fontInfo
         if ( TT_Get_Face_Properties( FACE, &FACE_PROPERTIES ) )
                 goto Fail;
 
-        if ( getCharMap( FACE, &CHAR_MAP ) )
+        if ( getCharMap( trueTypeVars, &CHAR_MAP ) )
                 goto Fail;
 
         if ( getNameFromNameTable( trueTypeVars, FAMILY_NAME, FAMILY_NAME_ID ) == 0 )

--- a/Driver/Font/TrueType/Adapter/ttwidths.c
+++ b/Driver/Font/TrueType/Adapter/ttwidths.c
@@ -89,7 +89,6 @@ MemHandle _pascal TrueType_Gen_Widths(
                         TextStyle            stylesToImplement,
                         MemHandle            varBlock ) 
 {
-        FileHandle             truetypeFile;
         TrueTypeOutlineEntry*  trueTypeOutline;
         TrueTypeVars*          trueTypeVars;
         FontHeader*            fontHeader;
@@ -108,31 +107,15 @@ MemHandle _pascal TrueType_Gen_Widths(
 
         /* get trueTypeVar block */
         trueTypeVars = MemLock( varBlock );
-        if( trueTypeVars == NULL )
-        {
-                MemReAlloc( varBlock, sizeof( TrueTypeVars ), HAF_NO_ERR );
-                trueTypeVars = MemLock( varBlock );
-        }
-        
 EC(     ECCheckBounds( (void*)trueTypeVars ) );
-
-        // get filename an load ttf file
-        FilePushDir();
-        FileSetCurrentPath( SP_FONT, TTF_DIRECTORY );
 
         // get filename an load ttf file 
         trueTypeOutline = LMemDerefHandles( MemPtrToHandle( (void*)fontInfo ), headerEntry->OE_handle );
-        truetypeFile = FileOpen( trueTypeOutline->TTOE_fontFileName, FILE_ACCESS_R | FILE_DENY_W );
-
-EC(     ECCheckFileHandle( truetypeFile ) );
 
         // get pointer to FontHeader
         fontHeader = LMemDerefHandles( MemPtrToHandle( (void*)fontInfo ), firstEntry->OE_handle );
 
-        if ( TT_Open_Face( truetypeFile, &FACE ) )
-                goto Fin;
-
-        if ( TT_Get_Face_Properties( FACE, &FACE_PROPERTIES ) )
+        if( TrueType_Lock_Face(trueTypeVars, trueTypeOutline) )
                 goto Fail;
 
         /* alloc Block for FontBuf, CharTableEntries, KernPairs and kerning values */
@@ -187,12 +170,9 @@ EC(     ECCheckFileHandle( truetypeFile ) );
         //TODO: adjust FB_height, FB_minTSB, FB_pixHeight and FB_baselinePos
         AdjustFontBuf( transMatrix, fontMatrix, fontBuf );
 
-Fail:
-        TT_Close_Face( FACE );
-Fin:        
-        FileClose( truetypeFile, FALSE );
+        TrueType_Unlock_Face( trueTypeVars );
+Fail:        
         MemUnlock( varBlock );
-        FilePopDir();
         return fontHandle;
 }
 
@@ -228,7 +208,6 @@ static void ConvertWidths( TRUETYPE_VARS, FontHeader* fontHeader, FontBuf* fontB
 
         TT_New_Glyph( FACE, &GLYPH );
         TT_New_Instance( FACE, &INSTANCE );
-        getCharMap( FACE, &CHAR_MAP );
 
         for( currentChar = fontHeader->FH_firstChar; currentChar <= fontHeader->FH_lastChar; ++currentChar )
         {

--- a/Driver/Font/TrueType/Adapter/ttwidths.c
+++ b/Driver/Font/TrueType/Adapter/ttwidths.c
@@ -95,7 +95,6 @@ MemHandle _pascal TrueType_Gen_Widths(
                         TextStyle            stylesToImplement,
                         MemHandle            varBlock ) 
 {
-        FileHandle             truetypeFile;
         TrueTypeOutlineEntry*  trueTypeOutline;
         TrueTypeVars*          trueTypeVars;
         FontHeader*            fontHeader;
@@ -114,31 +113,15 @@ MemHandle _pascal TrueType_Gen_Widths(
 
         /* get trueTypeVar block */
         trueTypeVars = MemLock( varBlock );
-        if( trueTypeVars == NULL )
-        {
-                MemReAlloc( varBlock, sizeof( TrueTypeVars ), HAF_NO_ERR );
-                trueTypeVars = MemLock( varBlock );
-        }
-        
 EC(     ECCheckBounds( (void*)trueTypeVars ) );
-
-        // get filename an load ttf file
-        FilePushDir();
-        FileSetCurrentPath( SP_FONT, TTF_DIRECTORY );
 
         // get filename an load ttf file 
         trueTypeOutline = LMemDerefHandles( MemPtrToHandle( (void*)fontInfo ), headerEntry->OE_handle );
-        truetypeFile = FileOpen( trueTypeOutline->TTOE_fontFileName, FILE_ACCESS_R | FILE_DENY_W );
-
-EC(     ECCheckFileHandle( truetypeFile ) );
 
         // get pointer to FontHeader
         fontHeader = LMemDerefHandles( MemPtrToHandle( (void*)fontInfo ), firstEntry->OE_handle );
 
-        if ( TT_Open_Face( truetypeFile, &FACE ) )
-                goto Fin;
-
-        if ( TT_Get_Face_Properties( FACE, &FACE_PROPERTIES ) )
+        if( TrueType_Lock_Face(trueTypeVars, trueTypeOutline) )
                 goto Fail;
 
         /* alloc Block for FontBuf, CharTableEntries, KernPairs and kerning values */
@@ -170,12 +153,9 @@ EC(     ECCheckFileHandle( truetypeFile ) );
         //TODO: adjust FB_height, FB_minTSB, FB_pixHeight and FB_baselinePos
         AdjustFontBuf( transMatrix, fontMatrix, fontBuf );
 
-Fail:
-        TT_Close_Face( FACE );
-Fin:        
-        FileClose( truetypeFile, FALSE );
+        TrueType_Unlock_Face( trueTypeVars );
+Fail:        
         MemUnlock( varBlock );
-        FilePopDir();
         return fontHandle;
 }
 
@@ -211,7 +191,6 @@ static void ConvertWidths( TRUETYPE_VARS, FontHeader* fontHeader, FontBuf* fontB
 
         TT_New_Glyph( FACE, &GLYPH );
         TT_New_Instance( FACE, &INSTANCE );
-        getCharMap( FACE, &CHAR_MAP );
 
         for( currentChar = fontHeader->FH_firstChar; currentChar <= fontHeader->FH_lastChar; ++currentChar )
         {

--- a/Driver/Font/TrueType/FreeType/ttraster.c
+++ b/Driver/Font/TrueType/FreeType/ttraster.c
@@ -275,11 +275,11 @@
 
     /* dispatch variables */
 
-    Function_Sweep_Init*    Proc_Sweep_Init;
-    Function_Sweep_Span*    Proc_Sweep_Span;
-    Function_Sweep_Span*    Proc_Sweep_Drop;
-    Function_Sweep_Step*    Proc_Sweep_Step;
-    Function_Sweep_Finish*  Proc_Sweep_Finish;
+    Function_Sweep_Init _near *    Proc_Sweep_Init;
+    Function_Sweep_Span _near *    Proc_Sweep_Span;
+    Function_Sweep_Span _near *    Proc_Sweep_Drop;
+    Function_Sweep_Step _near *    Proc_Sweep_Step;
+    Function_Sweep_Finish _near *  Proc_Sweep_Finish;
 
     TT_Vector*  coords;
 
@@ -320,7 +320,7 @@
 /*                                                                      */
 /************************************************************************/
 
-  static void  Set_High_Precision( RAS_ARGS Bool  High )
+  static void _near  Set_High_Precision( RAS_ARGS Bool  High )
   {
     if ( High )
     {
@@ -354,7 +354,7 @@
 /*                                                                          */
 /****************************************************************************/
 
-  static Bool  New_Profile( RAS_ARGS TStates  aState )
+  static Bool _near  New_Profile( RAS_ARGS TStates  aState )
   {
     if ( !ras.fProfile )
     {
@@ -414,7 +414,7 @@
 /*                                                                          */
 /****************************************************************************/
 
-  static Bool  End_Profile( RAS_ARG )
+  static Bool _near  End_Profile( RAS_ARG )
   {
     Long      h;
     PProfile  oldProfile;
@@ -585,7 +585,7 @@
 /*                                                                          */
 /****************************************************************************/
 
-  static void  Split_Bezier( TPoint*  base )
+  static void _near  Split_Bezier( TPoint*  base )
   {
     Long     a, b;
 
@@ -619,7 +619,7 @@
 /*                                                                          */
 /****************************************************************************/
 
-  static void  Push_Bezier( RAS_ARGS Long  x1, Long  y1,
+  static void _near  Push_Bezier( RAS_ARGS Long  x1, Long  y1,
                                      Long  x2, Long  y2,
                                      Long  x3, Long  y3 )
   {
@@ -644,7 +644,7 @@
 /*                                                                          */
 /****************************************************************************/
 
-  static Bool  Line_Up( RAS_ARGS Long  x1, Long  y1,
+  static Bool _near  Line_Up( RAS_ARGS Long  x1, Long  y1,
                                  Long  x2, Long  y2,
                                  Long  miny, Long  maxy )
   {
@@ -755,7 +755,7 @@
   }
 
 
-  static Bool  Line_Down( RAS_ARGS Long  x1, Long  y1,
+  static Bool _near  Line_Down( RAS_ARGS Long  x1, Long  y1,
                                    Long  x2, Long  y2,
                                    Long  miny, Long  maxy )
   {
@@ -787,7 +787,7 @@
 /*                                                                          */
 /****************************************************************************/
 
-  static Bool  Bezier_Up( RAS_ARGS Long  miny, Long  maxy )
+  static Bool _near  Bezier_Up( RAS_ARGS Long  miny, Long  maxy )
   {
     Long   y1, y2, e, e2, e0;
     Short  f1;
@@ -916,7 +916,7 @@
 /*                                                                          */
 /****************************************************************************/
 
-  static Bool  Bezier_Down( RAS_ARGS Long  miny, Long  maxy )
+  static Bool _near  Bezier_Down( RAS_ARGS Long  miny, Long  maxy )
   {
     TPoint*  arc = ras.arc;
     Bool     result, fresh;
@@ -951,7 +951,7 @@
 /*                                                                          */
 /****************************************************************************/
 
-  static Bool  Line_To( RAS_ARGS Long  x, Long  y )
+  static Bool _near  Line_To( RAS_ARGS Long  x, Long  y )
   {
     /* First, detect a change of direction */
 
@@ -1030,7 +1030,7 @@
 /*                                                                          */
 /****************************************************************************/
 
-  static Bool  Bezier_To( RAS_ARGS Long  x,
+  static Bool _near  Bezier_To( RAS_ARGS Long  x,
                                    Long  y,
                                    Long  cx,
                                    Long  cy )
@@ -1144,7 +1144,7 @@
 #undef  SWAP_
 #define SWAP_(x,y)  { Long swap = x; x = y; y = swap; }
 
-  static Bool  Decompose_Curve( RAS_ARGS UShort  first,
+  static Bool _near  Decompose_Curve( RAS_ARGS UShort  first,
                                          UShort  last,
                                          Bool    flipped )
   {
@@ -1276,7 +1276,7 @@
 /*                                                                          */
 /****************************************************************************/
 
-  static Bool  Convert_Glyph( RAS_ARGS int  flipped )
+  static Bool _near  Convert_Glyph( RAS_ARGS int  flipped )
   {
     Short     i;
     UShort    start;
@@ -1340,7 +1340,7 @@
 /*                                              */
 /************************************************/
 
-  static void  Init_Linked( TProfileList*  l )
+  static void _near  Init_Linked( TProfileList*  l )
   {
     *l = NULL;
   }
@@ -1354,7 +1354,7 @@
 /*                                              */
 /************************************************/
 
-  static void  InsNew( PProfileList  list,
+  static void _near  InsNew( PProfileList  list,
                        PProfile      profile )
   {
     PProfile  *old, current;
@@ -1386,7 +1386,7 @@
 /*                                               */
 /*************************************************/
 
-  static void  DelOld( PProfileList  list,
+  static void _near  DelOld( PProfileList  list,
                        PProfile      profile )
   {
     PProfile  *old, current;
@@ -1420,7 +1420,7 @@
 /*                                              */
 /************************************************/
 
-  static void  Update( PProfile  first )
+  static void _near  Update( PProfile  first )
   {
     PProfile  current = first;
 
@@ -1446,7 +1446,7 @@
 /*                                              */
 /************************************************/
 
-  static void  Sort( PProfileList  list )
+  static void _near  Sort( PProfileList  list )
   {
     PProfile  *old, current, next;
 
@@ -1497,14 +1497,14 @@
 /*                                                                     */
 /***********************************************************************/
 
-  static void  Vertical_Sweep_Init( RAS_ARGS Short*  min, Short*  max )
+  static void _near  Vertical_Sweep_Init( RAS_ARGS Short*  min, Short*  max )
   {
     ras.traceOfs  = ( ras.target.rows - 1 - *min ) * ras.target.cols;
     ras.traceIncr = -ras.target.cols;
   }
 
 
-  static void  Vertical_Sweep_Span( RAS_ARGS Short       y,
+  static void _near  Vertical_Sweep_Span( RAS_ARGS Short       y,
                                              TT_F26Dot6  x1,
                                              TT_F26Dot6  x2,
                                              PProfile    left,
@@ -1553,7 +1553,7 @@
   }
 
 
-  static void  Vertical_Sweep_Drop( RAS_ARGS Short       y,
+  static void _near  Vertical_Sweep_Drop( RAS_ARGS Short       y,
                                              TT_F26Dot6  x1,
                                              TT_F26Dot6  x2,
                                              PProfile    left,
@@ -1658,13 +1658,13 @@
   }
 
 
-  static void Vertical_Sweep_Step( RAS_ARGS Short y )
+  static void _near Vertical_Sweep_Step( RAS_ARGS Short y )
   {
     ras.traceOfs += ras.traceIncr;
   }
 
 
-  static void Vertical_Sweep_Finish( RAS_ARG )
+  static void _near Vertical_Sweep_Finish( RAS_ARG )
   {
     /* nothing to do */
   }
@@ -1681,7 +1681,7 @@
 /*                                                                     */
 /***********************************************************************/
 
-  static void  Vertical_Region_Sweep_Init( RAS_ARGS 
+  static void _near  Vertical_Region_Sweep_Init( RAS_ARGS 
                                            Short*  min, 
                                            Short*  max )
   {
@@ -1690,7 +1690,7 @@
     ras.traceOfsLastLine = -1;
   }
 
-  static void  Vertical_Region_Sweep_Span( RAS_ARGS Short       y,
+  static void _near  Vertical_Region_Sweep_Span( RAS_ARGS Short       y,
                                                     TT_F26Dot6  x1,
                                                     TT_F26Dot6  x2,
                                                     PProfile    left,
@@ -1724,7 +1724,7 @@
     }
   }
 
-  static void  Vertical_Region_Sweep_Drop( RAS_ARGS Short       y,
+  static void _near  Vertical_Region_Sweep_Drop( RAS_ARGS Short       y,
                                                     TT_F26Dot6  x1,
                                                     TT_F26Dot6  x2,
                                                     PProfile    left,
@@ -1733,7 +1733,7 @@
     /* nothing to do */
   } 
 
-  static void  Vertical_Region_Sweep_Step( RAS_ARGS Short y )
+  static void _near  Vertical_Region_Sweep_Step( RAS_ARGS Short y )
   {
     Short*  target;
     Short*  targetLastLine;
@@ -1772,7 +1772,7 @@
     ras.traceIncr        = 0;
   }
 
-  static void Vertical_Region_Sweep_Finish( RAS_ARG )
+  static void _near  Vertical_Region_Sweep_Finish( RAS_ARG )
   {
     Short*  target;
 
@@ -1797,13 +1797,13 @@
 /*                                                                     */
 /***********************************************************************/
 
-  static void  Horizontal_Sweep_Init( RAS_ARGS Short*  min, Short*  max )
+  static void _near  Horizontal_Sweep_Init( RAS_ARGS Short*  min, Short*  max )
   {
     /* nothing, really */
   }
 
 
-  static void  Horizontal_Sweep_Span( RAS_ARGS Short       y,
+  static void _near  Horizontal_Sweep_Span( RAS_ARGS Short       y,
                                                TT_F26Dot6  x1,
                                                TT_F26Dot6  x2,
                                                PProfile    left,
@@ -1833,7 +1833,7 @@
   }
 
 
-  static void  Horizontal_Sweep_Drop( RAS_ARGS Short       y,
+  static void _near  Horizontal_Sweep_Drop( RAS_ARGS Short       y,
                                                TT_F26Dot6  x1,
                                                TT_F26Dot6  x2,
                                                PProfile    left,
@@ -1920,12 +1920,12 @@
   }
 
 
-  static void Horizontal_Sweep_Step( RAS_ARGS Short y )
+  static void _near Horizontal_Sweep_Step( RAS_ARGS Short y )
   {
     /* Nothing, really */
   }
 
-    static void Horizontal_Sweep_Finish( RAS_ARG )
+    static void _near Horizontal_Sweep_Finish( RAS_ARG )
   {
     /* nothing to do */
   }
@@ -2134,7 +2134,7 @@
 /*                                                                  */
 /********************************************************************/
 
-  static Bool  Draw_Sweep( RAS_ARG )
+  static Bool _near  Draw_Sweep( RAS_ARG )
   {
     Short  y, y_change, y_height;
 
@@ -2186,11 +2186,7 @@
 
     /* Now inits the sweep */
 
-#ifdef __GEOS__
-    ProcCallFixedOrMovable_cdecl( ras.Proc_Sweep_Init, RAS_VARS  &min_Y, &max_Y );
-#else
     ras.Proc_Sweep_Init( RAS_VARS  &min_Y, &max_Y );
-#endif  /* __GEOS__ */
 
     /* Then compute the distance of each profile from min_Y */
 
@@ -2286,11 +2282,7 @@
             }
           }
 
-#ifdef __GEOS__
-          ProcCallFixedOrMovable_cdecl( ras.Proc_Sweep_Span, RAS_VARS  y, x1, x2, P_Left, P_Right );
-#else
           ras.Proc_Sweep_Span( RAS_VARS  y, x1, x2, P_Left, P_Right );
-#endif  /* __GEOS__ */
 
    Skip_To_Next:
 
@@ -2306,11 +2298,7 @@
 
    Next_Line:
 
-#ifdef __GEOS__
-        ProcCallFixedOrMovable_cdecl( ras.Proc_Sweep_Step, RAS_VARS y );
-#else
         ras.Proc_Sweep_Step( RAS_VARS y );
-#endif  /* __GEOS__ */
 
         y++;
 
@@ -2351,19 +2339,11 @@
     /* for gray-scaling, flushes the bitmap scanline cache */
     while ( y <= max_Y )
     {
-#ifdef __GEOS__
-      ProcCallFixedOrMovable_cdecl( ras.Proc_Sweep_Step, RAS_VARS y );
-#else
       ras.Proc_Sweep_Step( RAS_VARS y );
-#endif  /* __GEOS__ */
       y++;
     }
 
-#ifdef __GEOS__
-    ProcCallFixedOrMovable_cdecl( ras.Proc_Sweep_Finish, RAS_VAR );
-#else
     ras.Proc_Sweep_Finish( RAS_VAR );
-#endif
     return SUCCESS;
 
 Scan_DropOuts :
@@ -2377,19 +2357,11 @@ Scan_DropOuts :
       {
         P_Left->countL = 0;
         /* dropouts--;    -- this is useful when debugging only */
-#ifdef __GEOS__
-        ProcCallFixedOrMovable_cdecl( ras.Proc_Sweep_Drop, RAS_VARS  y,
-                                       P_Left->X,
-                                       P_Right->X,
-                                       P_Left,
-                                       P_Right );
-#else
         ras.Proc_Sweep_Drop( RAS_VARS  y,
                                        P_Left->X,
                                        P_Right->X,
                                        P_Left,
                                        P_Right );
-#endif  /* __GEOS__ */
       }
 
       P_Left  = P_Left->link;

--- a/Driver/Font/TrueType/Main/truetypeInit.asm
+++ b/Driver/Font/TrueType/Main/truetypeInit.asm
@@ -76,10 +76,9 @@ TrueTypeInit	proc	far
 	; We also need a block to use for variables. We don't
 	; need it yet, either.
 	;
-	mov	ax, size TrueTypeVars		;ax <- size of block
+	mov	ax, TRUETYPE_BLOCK_SIZE		;ax <- size of block
 	mov	bx, handle 0			;bx <- make TrueType owner
-	mov	cx, mask HF_DISCARDABLE \
-		 or mask HF_SWAPABLE \
+	mov	cx, mask HF_SWAPABLE \
 		 or mask HF_SHARABLE \
 		 or mask HF_DISCARDED \
 		 or (mask HAF_NO_ERR shl 8) 	;cl, ch <- alloc flags

--- a/Installed/Driver/Font/TrueType/Makefile
+++ b/Installed/Driver/Font/TrueType/Makefile
@@ -4,31 +4,31 @@
 # If you edit it, you will lose your changes, should it be regenerated.
 #
 GEODE           = truetype
-MAIN            = truetypeEscape.asm ansic_runtime.asm mainManager.asm\
-                  truetypeWidths.asm ansic_memory.asm truetypeMetrics.asm\
-                  truetypeInit.asm truetypeEC.asm truetypeChars.asm\
-                  truetypePath.asm truetypeMacros.def truetypeVariable.def\
-                  truetypeConstant.def
-ADAPTER         = ttchars.c ttinit.c ttmetrics.c ttcharmapper.c ttwidths.c\
-                  ttpath.c ttcharmapper.h ttwidths.h ttinit.h ttmetrics.h\
-                  ttadapter.h
-FREETYPE        = ttcache.c ttraster.c ttmutex.c ttgload.c ttextend.c\
-                  ttcalc.c ttapi.c ftxkern.c ttinterp.c ttload.c ttfile.c\
-                  ttcmap.c ttobjs.c ttmemory.c ttcache.h ttcmap.h\
-                  ttconfig.h freetype.h ttgload.h ttfile.h ttinterp.h\
-                  ttload.h tttables.h ttobjs.h fterrid.h ttraster.h\
-                  ttengine.h tttypes.h ttmutex.h ft_conf.h ttextend.h\
-                  ftnameid.h ttcalc.h ftxkern.h ttmemory.h tttags.h
+ADAPTER         = ttadapter.c ttcharmapper.c ttchars.c ttinit.c ttmetrics.c\
+                  ttpath.c ttwidths.c ttadapter.h ttcharmapper.h ttchars.h\
+                  ttinit.h ttmetrics.h ttwidths.h
+FREETYPE        = ftxkern.c ttapi.c ttcache.c ttcalc.c ttcmap.c ttextend.c\
+                  ttfile.c ttgload.c ttinterp.c ttload.c ttmemory.c\
+                  ttmutex.c ttobjs.c ttraster.c freetype.h fterrid.h\
+                  ftnameid.h ftxkern.h ft_conf.h ttcache.h ttcalc.h\
+                  ttcmap.h ttconfig.h ttengine.h ttextend.h ttfile.h\
+                  ttgload.h ttinterp.h ttload.h ttmemory.h ttmutex.h\
+                  ttobjs.h ttraster.h tttables.h tttags.h tttypes.h
+MAIN            = ansic_memory.asm ansic_runtime.asm mainManager.asm\
+                  truetypeChars.asm truetypeEC.asm truetypeEscape.asm\
+                  truetypeInit.asm truetypeMetrics.asm truetypePath.asm\
+                  truetypeWidths.asm truetypeConstant.def\
+                  truetypeMacros.def truetypeVariable.def
 UI_TO_RDFS      =
-OBJS            = ttchars.obj ttinit.obj ttmetrics.obj ttcharmapper.obj\
-                  ttwidths.obj ttpath.obj ttcache.obj ttraster.obj\
-                  ttmutex.obj ttgload.obj ttextend.obj ttcalc.obj ttapi.obj\
-                  ftxkern.obj ttinterp.obj ttload.obj ttfile.obj ttcmap.obj\
-                  ttobjs.obj ttmemory.obj
+OBJS            = ttadapter.obj ttcharmapper.obj ttchars.obj ttinit.obj\
+                  ttmetrics.obj ttpath.obj ttwidths.obj ftxkern.obj\
+                  ttapi.obj ttcache.obj ttcalc.obj ttcmap.obj ttextend.obj\
+                  ttfile.obj ttgload.obj ttinterp.obj ttload.obj\
+                  ttmemory.obj ttmutex.obj ttobjs.obj ttraster.obj
 COMMON          =
 MODULES         = Main
 CMODULES        = Adapter FreeType
-SRCS            = $(MAIN) $(ADAPTER) $(FREETYPE) $(COMMON)
+SRCS            = $(ADAPTER) $(FREETYPE) $(MAIN) $(COMMON)
 LOBJS           =
 
 SYSMAKEFILE     = geode.mk

--- a/Installed/Driver/Font/TrueType/dependencies.mk
+++ b/Installed/Driver/Font/TrueType/dependencies.mk
@@ -13,6 +13,18 @@ Main.eobj: Main/mainManager.asm \
                 truetypeMetrics.asm truetypePath.asm truetypeInit.asm \
                 truetypeEscape.asm ../FontCom/fontcomEscape.asm \
                 truetypeEC.asm ansic_runtime.asm ansic_memory.asm
+ttadapter.obj \
+ttadapter.eobj: Adapter/ttadapter.h geos.h ec.h fontID.h file.h \
+                Adapter/../FreeType/freetype.h \
+                Adapter/../FreeType/fterrid.h \
+                Adapter/../FreeType/ftnameid.h \
+                Adapter/../FreeType/ttengine.h \
+                Adapter/../FreeType/tttypes.h \
+                Adapter/../FreeType/ttconfig.h \
+                Adapter/../FreeType/ft_conf.h resource.h graphics.h \
+                font.h color.h heap.h lmem.h Ansi/stdlib.h \
+                Adapter/../FreeType/ttmutex.h \
+                Adapter/../FreeType/ttcalc.h Adapter/ttmetrics.h
 ttchars.obj \
 ttchars.eobj: Adapter/ttadapter.h geos.h ec.h fontID.h file.h \
                 Adapter/../FreeType/freetype.h \
@@ -50,6 +62,7 @@ ttmetrics.eobj: Adapter/ttadapter.h geos.h ec.h fontID.h file.h \
                 Adapter/../FreeType/ttcalc.h Adapter/ttmetrics.h
 ttcharmapper.obj \
 ttcharmapper.eobj: Adapter/ttcharmapper.h geos.h FreeType/freetype.h \
+                Adapter/ttadapter.h \
                 FreeType/fterrid.h FreeType/ftnameid.h unicode.h
 ttwidths.obj \
 ttwidths.eobj: geos.h ec.h unicode.h graphics.h fontID.h font.h color.h \

--- a/README.md
+++ b/README.md
@@ -35,19 +35,19 @@ Document is work in progress.... stay tuned!
 
 ## Building PC/GEOS SDK
 Build pmake tool:
-- `cd pcgeos/Tools/pmake/pmake`
+- `cd %ROOT_DIR%/Tools/pmake/pmake`
 - `wmake install`
 
 Build all the other SDK Tools:
-- `cd pcgeos/Installed/Tools`
+- `cd %ROOT_DIR%/Installed/Tools`
 - `pmake install`
 
 Build all PC/GEOS (target) components:
-- `cd pcgeos/Installed`
+- `cd %ROOT_DIR%/Installed`
 - `pmake`
 
 Build the target environment:
-- `cd pcgeos/Tools/build/product/bbxensem/Scripts`
+- `cd %ROOT_DIR%/Tools/build/product/bbxensem/Scripts`
 - `perl -I. buildbbx.pl`
   - the answers to the questions from the above perl-script are:
     - nt (for the platform)
@@ -60,7 +60,7 @@ Build the target environment:
 
 Launch the target environment in dosbox:
 - make sure dosbox is added to your path variable, or [pcgeos-basebox](https://github.com/bluewaysw/pcgeos-basebox/tags) is installed and configured using BASEBOX environmental variable
-- `cd pcgeos`
+- `cd %ROOT_DIR%`
 - `bin/target`
   - the "swat" debugger stops immediately after the first stage of the boot process
   - enter `quit` at the "=>" prompt to detach the debugger and launch PC/GEOS stand-alone

--- a/README.md
+++ b/README.md
@@ -60,8 +60,7 @@ Build the target environment:
 
 Launch the target environment in dosbox:
 - make sure dosbox is added to your path variable, or [pcgeos-basebox](https://github.com/bluewaysw/pcgeos-basebox/tags) is installed and configured using BASEBOX environmental variable
-- `cd %ROOT_DIR%`
-- `bin/target`
+- `%ROOT_DIR%/bin/target`
   - the "swat" debugger stops immediately after the first stage of the boot process
   - enter `quit` at the "=>" prompt to detach the debugger and launch PC/GEOS stand-alone
     - or: enter `c` to launch with the debugger running in the background (slower)

--- a/TechDocs/Markdown/Ddk/ddkfont.md
+++ b/TechDocs/Markdown/Ddk/ddkfont.md
@@ -1,26 +1,13 @@
+## 4 Font Driver
 
-FILE: 	README.fontDr
-DESC:	This document describes the interface and interactions of font
-	drivers in PC/GEOS
-AUTHOR:	Gene Anderson
-DATE:	01/21/91
+AUTHOR:	Gene Anderson (01/21/91)
 
-	$Id: README.font,v 1.4.25.1 97/03/29 07:08:03 canavese Exp $
+This document describes the interface and interactions of font drivers in
+PC/GEOS.
 
-------------------------------------------------------------------------------
-	CONTENTS
-------------------------------------------------------------------------------
-	Overview
-	Initialization Routines
-	Data Routines
-	Metrics Routines
-	Debugging Tips
+### 4.1 Overview
 
-------------------------------------------------------------------------------
-	Overview
-------------------------------------------------------------------------------
-
-	In PC/GEOS, outline font drivers play a vital role in the
+In PC/GEOS, outline font drivers play a vital role in the
 WYSIWYG rendering engine.  They are called to generate the metrics for
 a font at any pointsize, rotation or scale factor that a program may
 request, making this information transparently available.  When the
@@ -28,7 +15,7 @@ font is actually drawn to the screen (or to memory for printing), the
 font drivers are called to generate bitmaps for the actual images of
 the characters.
 
-	A program will normally specify a particular typeface
+A program will normally specify a particular typeface
 (FontIDs) and pointsize (WBFixed) using GrSetFont().  Additional
 styles (TextStyles) may be specified using GrSetTextStyle().  Some
 programs, such as GeoDraw, may also specify an angle of rotation using
@@ -38,7 +25,7 @@ printing or rendering to a different device, using window routines
 similar to the graphics transformation routines above.  All these
 elements combine to specify a unique 'font' to the system.
 
-	A typeface is referred to by a 16-bit ID (FontIDs).  Part of
+A typeface is referred to by a 16-bit ID (FontIDs).  Part of
 the PC/GEOS kernel is a Font Manager, and it tracks the requests and
 usage of fonts in the system via these IDs and other font attributes.
 It maintains an array of structures (FontsAvailEntry) for each font in
@@ -48,7 +35,7 @@ display.  Each of these entries has a corresponding chunk of data
 (FontInfo), which specifies more information about the typeface, such
 as the ASCII name, and which styles are available as direct outlines.
 
-	When a routine needs a particular piece of font information,
+When a routine needs a particular piece of font information,
 it asks the Font Manager to get the font in question.  This may be
 accomplished simply if the font has a hand-tuned bitmap that is
 appropriate.  If no bitmap exists, however, the font driver will be
@@ -58,47 +45,45 @@ metrics information, and references to each character in the font
 indicating whether it exists or not, and whether a bitmap for it has
 been built.
 
-	When the video driver renders text on screen, it checks to see
+When the video driver renders text on screen, it checks to see
 if a bitmap for the character it is about to draw exists or not.  If
 not, it asks the Font Manager to get a bitmap for the character.  The
 Font Manager in turn calls the appropriate font driver and requests
 the bitmap using the function DR_FONT_GEN_CHAR.
 
-	This process goes on as the system runs.  Eventually, the font
+This process goes on as the system runs.  Eventually, the font
 may be unused for such a time period as to cause the data block to be
 discarded by the Heap Manager.  If the font is requested again, the
 Font Manager will call the font driver with DR_FONT_GEN_WIDTHS, and
 the whole process starts over.
 
-	In addition to the process of requesting font metrics and
+In addition to the process of requesting font metrics and
 corresponding character bitmaps, programs may request metrics about a
 particular character in which case the Font Manager calls the font
 driver with DR_FONT_CHAR_METRICS.  Alternatively, a program may
 request the outline data for a particular character, in which case the
 font driver is called with DR_FONT_GEN_PATH.
 
-	There are also a number of initialization routines that the
+There are also a number of initialization routines that the
 font driver must support.  These are used to start and stop the font
 driver, as well as give it a chance to initialize any of its own
 fonts.
 
-	Finally, there are a number of driver 'escape functions',
+Finally, there are a number of driver 'escape functions',
 which the font driver may choose to support or not, as is appropriate.
 These include functions such as adding or deleting a font from the
 system.
 
-------------------------------------------------------------------------------
-	Initialization Routines
-------------------------------------------------------------------------------
+### 4.2 Initialization Routines
 
-DR_INIT
+*DR_INIT*
 
-	DR_INIT is called for all drivers.  This should be used to
+DR_INIT is called for all drivers.  This should be used to
 initialize any necessary data structures and memory.  However, care
 should be taken to keep memory usage at this stage at an absolute
 minimum as the driver may never get called again during this session.
 
-	For example, the Nimbus driver allocates handles for a variety
+For example, the Nimbus driver allocates handles for a variety
 of blocks it uses (one for variables, one for the generated bitmap),
 but without allocating the associated memory (ie. HF_DISCARDED).  They
 are also marked as discardable (ie. HF_DISCARDABLE), so the first
@@ -108,87 +93,85 @@ two handles are used.  If the Nimbus driver is unused for a long
 period of time, these blocks may eventually be discarded as well.
 
 
-DR_EXIT
+*DR_EXIT*
 
-	DR_EXIT is also called for all drivers, and is the counterpart
+DR_EXIT is also called for all drivers, and is the counterpart
 of DR_INIT.  This function should clean up any memory or resources
 that have been allocated by the driver, generally things that were
 allocated in DR_INIT.
 
 
-DR_FONT_INIT_FONTS
+*DR_FONT_INIT_FONTS*
 
-	DR_FONT_INIT_FONTS is intended to allow the font driver to
+DR_FONT_INIT_FONTS is intended to allow the font driver to
 inform the system of any additional fonts it may have.  The PC/GEOS
 kernel searches the disk for any fonts in it's format, but by
 definition most font drivers will be dealing with non-PC/GEOS fonts.
 
-	To add a font to the system, two structures must be modified
+To add a font to the system, two structures must be modified
 or created.  Both of these structures reside in the font manager's
 information block, which is passed to the various font driver
 functions.
 
-	First, a FontsAvailEntry must be added, which specifies to the
+First, a FontsAvailEntry must be added, which specifies to the
 system that this particular FontIDs value is available, and where
 additional information about the font is stored.
 
-	The additional information is a separate chunk in the font
+The additional information is a separate chunk in the font
 manager's block.  It consists of a FontInfo structure, followed by as
 many PointSizeEntry structures (for bitmap fonts) and OutlineDataEntry
 structures (for outline fonts) as is appropriate.
 
-	"As many is appropriate" for bitmap fonts constitutes one
+"As many is appropriate" for bitmap fonts constitutes one
 PointSizeEntry for each pointsize/style/weight combination.  If there
 are no bitmaps for the FontIDs value in question, FI_pointSizeTab is
 zero (0) and there are no PointSizeEntry structures.
 
-	"As many is appropriate" for outline fonts constitutes one
+"As many is appropriate" for outline fonts constitutes one
 OutlineDataEntry for each style/weight combination (note this does not
 include pointsize, as that is irrelevant for outline fonts).  If there
 are no outlines for the FontIDs value in question, FI_outlineTab is
 zero (0) and there are no OutlineDataEntry structures.
 
-------------------------------------------------------------------------------
-	Data Routines
-------------------------------------------------------------------------------
+### 4.3 Data Routines
 
-DR_FONT_GEN_WIDTHS
+*DR_FONT_GEN_WIDTHS*
 
-	DR_FONT_GEN_WIDTHS is called to generate the metrics and basic
+DR_FONT_GEN_WIDTHS is called to generate the metrics and basic
 information for one font.  In PC/GEOS, a different font is constituted
 by:
-		typeface (FontIDs)
-		pointsize (WBFixed)
-		style (TextStyle)
-		weight (FontWeight)
-		width (FontWidth)
-		transformation (TMatrix)
+* typeface (FontIDs)
+* pointsize (WBFixed)
+* style (TextStyle)
+* weight (FontWeight)
+* width (FontWidth)
+* transformation (TMatrix)
 
-	What the system expects back from this routine is a buffer
+What the system expects back from this routine is a buffer
 containing the following:
 
-		FontBuf - font header and metrics information
-			+
-		CharTableEntry #1
-		CharTableEntry #2
-		      [...]
-		CharTableEntry #n
-			+
-		[optional cached data]
-			+
-		[optional KernPair[1..m]]
-		[optional BBFixed[1..m]]
+        FontBuf - font header and metrics information
+                +
+        CharTableEntry #1
+        CharTableEntry #2
+                [...]
+        CharTableEntry #n
+                +
+        [optional cached data]
+                +
+        [optional KernPair[1..m]]
+        [optional BBFixed[1..m]]
 
-	Each CharTableEntry contains the pen width of the character,
+Each CharTableEntry contains the pen width of the character,
 flags about the size and shape of the character, and the offset to the
 actual bitmap data for the character if it is built (or a flag
 indicating it hasn't yet been built).
 
-	Given this structure, the system will call the font driver
+Given this structure, the system will call the font driver
 back for each character when it is needed, via the DR_FONT_GEN_CHAR
 routine.
 
-	The kerning information is a pair of matched tables.
+The kerning information is a pair of matched tables.
 FB_kernCount contains the number of kerning pairs.  FB_kernPairPtr
 points to an array of KernPair structures, which are left char / right
 char combinations that specify each kerning pair.  FB_kernValuePtr
@@ -197,7 +180,7 @@ specifying the adjustment for the corresponding character pair.  Negative
 values mean move the characters closer; positive values mean move them
 further apart.
 
-	A note about DR_FONT_GEN_WIDTHS: outlines for all styles and
+A note about DR_FONT_GEN_WIDTHS: outlines for all styles and
 all style combinations are generally not available.  Underline and
 strikethrough are rendered by the kernel, and so need not be worried
 about.  Some fonts have plain, bold, italic, and bold-italic
@@ -206,7 +189,7 @@ the best case, this leaves superscript and subscript or any
 combination involving them unaccounted for.  In the worst case, this
 may leave every combination of TextStyles except plain unaccounted for!
 
-	In the case a direct outline is not available, the font driver
+In the case a direct outline is not available, the font driver
 is expected to "do its best".  This involves tricks like scaling and
 translating for superscript and subscript, and obliquing for creating
 italic.  To this end, a kernel routine (XXX: not yet written) is
@@ -216,7 +199,7 @@ Superscript', and 'Plain' and 'Bold' outlines are available, the best
 thing to do is to select the 'Bold' outline and scale and translate it
 to simulate the 'Superscript' attribute.
 
-	The "optional cached data" is just that: data that the font
+The "optional cached data" is just that: data that the font
 driver may choose to store in the font.  There is no explicit
 reference to this data, but it can quickly be found by adding the size
 of the FontBuf plus the appropriate number of CharTableEntry
@@ -228,58 +211,59 @@ font, and a reference to which set of routines will be used for
 rasterizing the bitmap or region data.
 
 
-DR_FONT_GEN_CHAR
+*DR_FONT_GEN_CHAR*
 
-	DR_FONT_GEN_CHAR is called to generate the bitmap for a single
+DR_FONT_GEN_CHAR is called to generate the bitmap for a single
 character.  The resulting data should be added to the FontBuf block
 returned by DR_FONT_GEN_WIDTHS after it has been resized
 appropriately.  The system supports two varieties of character data,
 one simple and the other compacted.
 
-	The first format is simple bitmap data, comprised of a header
+The first format is simple bitmap data, comprised of a header
 (CharData) containing the bounds and offset of the bitmap (in device
 coordinates) for where it should drawn relative to the top of the
 nominal font box.
 
-	This is followed by the data bytes.  The data should be
+This is followed by the data bytes.  The data should be
 byte-padded, and the in the data, ones are 'on' and zeroes are 'off'.
 
 Shown below is an example of the letter 'i':
-	byte	6		;width (CD_pictureWidth)
-	byte	10		;height (CD_numRows)
-	byte	3		;y offset (CD_yoff)
-	byte	2		;x offset (CD_xoff)
-	byte	00110000b	;(CD_data)
-	byte	00110000b
-	byte	00000000b
-	byte	11110000b
-	byte	00110000b
-	byte	00110000b
-	byte	00110000b
-	byte	00110000b
-	byte	00110000b
-	byte	11111100b
 
-	(0,0)
-	|
-	|
-	|
-	+--* (2,3)
-	(CD_xoff, CD_yoff)
-	   +----------+
-	   |    ##    |
-	   |    ##    |
-	   |          |
-	   |  ####    |
-	   |    ##    |
-	   |    ##    |
-	   |    ##    |
-	   |    ##    |
-	   |    ##    |
-	   |  ######  |
-	   +----------+
+        byte    6               ;width (CD_pictureWidth)
+        byte    10              ;height (CD_numRows)
+        byte    3               ;y offset (CD_yoff)
+        byte    2               ;x offset (CD_xoff)
+        byte    00110000b       ;(CD_data)
+        byte    00110000b
+        byte    00000000b
+        byte    11110000b
+        byte    00110000b
+        byte    00110000b
+        byte    00110000b
+        byte    00110000b
+        byte    00110000b
+        byte    11111100b
 
-	The second format is storing the character as a region.  This
+        (0,0)
+        |
+        |
+        |
+        +--* (2,3)
+             (CD_xoff, CD_yoff)
+           +----------+
+           |    ##    |
+           |    ##    |
+           |          |
+           |  ####    |
+           |    ##    |
+           |    ##    |
+           |    ##    |
+           |    ##    |
+           |    ##    |
+           |  ######  |
+           +----------+
+
+The second format is storing the character as a region.  This
 amounts to a scanline compression format, and works quite well for
 characters at 0, 90, 180 and 270 degree rotations.  It works
 reasonably well for characters at an arbitrary angle of rotation, and
@@ -288,15 +272,15 @@ in a script font like Shattuck Avenue.  The cutoff point between
 storing characters as bitmaps and as regions is 125 lines high (eg.
 125 point at 72 DPI, 30 point at 300 DPI, etc.)
 
-	There is a header (RegionCharData) similar to the header for
+There is a header (RegionCharData) similar to the header for
 bitmap characters.  There are two additional pieces of information:
 the size of the data for the region (in bytes), and the full bounds of
 the region data, which are used for drawing the region.
 
-	More details about the region format can be found in the
+More details about the region format can be found in the
 documentation about the graphics system.
 
-	A note about DR_FONT_GEN_CHAR: characters are requested on an
+A note about DR_FONT_GEN_CHAR: characters are requested on an
 as-needed basis.  The means the font will start with the
 FontBuf+CharTableEntry+KernPair+BBFixed information in the block.  As
 characters are added, the font driver will be adding data to this
@@ -308,7 +292,7 @@ individual FontBuf blocks below 10K in size.  This may not be possible
 at very large pointsizes, but is a general goal of the system to
 improve performance.
 
-	To this end, the font driver should use information which is
+To this end, the font driver should use information which is
 maintained in the CharTableEntry for each character and the FontBuf.
 FB_heapCount is the current usage counter for the font.  CTE_usage is
 the current usage counter for that character.  Given these values, it
@@ -318,73 +302,71 @@ delete this LRU character, thereby freeing up space for additional
 character(s) in the FontBuf block.  A kernel routine (XXX: not
 written) is provided to do this.
 
-	After DR_FONT_GEN_WIDTHS is called, then DR_FONT_GEN_CHAR
+After DR_FONT_GEN_WIDTHS is called, then DR_FONT_GEN_CHAR
 is called several times, the results will be something like what is
 below.  The FontBuf block will have been expanded to include the
 character bitmap/region data, although because of the LRU caching
 scheme, the characters may not be in any particular order.
 
-		FontBuf - font header and metrics information
-			+
-		CharTableEntry #1
-		CharTableEntry #2
-		      [...]
-		CharTableEntry #n
-			+
-		[optional cached data]
-			+
-		[optional KernPair[1..m]]
-		[optional BBFixed[1..m]]
-			+
-		Region/CharData #a
-		Region/CharData #b
-			[...]
-		Region/CharData #c
+        FontBuf - font header and metrics information
+                +
+        CharTableEntry #1
+        CharTableEntry #2
+                [...]
+        CharTableEntry #n
+                +
+        [optional cached data]
+                +
+        [optional KernPair[1..m]]
+        [optional BBFixed[1..m]]
+                +
+        Region/CharData #a
+        Region/CharData #b
+                [...]
+        Region/CharData #c
 
-------------------------------------------------------------------------------
-	Metrics Routines
-------------------------------------------------------------------------------
+### 4.4 Metrics Routines
 
-DR_FONT_CHAR_METRICS
+*DR_FONT_CHAR_METRICS*
 
-	DR_FONT_CHAR_METRICS is called to return metrics information
+DR_FONT_CHAR_METRICS is called to return metrics information
 about a particular character in a font.  The information is in
 document coordinates, which is to say it is not affected by scaling,
 rotation, etc. that modifies the way the document is viewed, but
 simply by the pointsize and font attributes requested.
 
-	There are currently four pieces of information returned: min
+There are currently four pieces of information returned: min
 x, min y, max x and max y.  These values are relative to (0,0) at the
 baseline/starting pen position:
 
-(xmin,ymax)	(xmax,ymax)
-	+------+
-	|    ##|
-	|    ##|
-	|      |
-	|  ####|
-	|    ##|
-	|    ##|
-	|    ##|
-	|    ##|
-	|    ##|
-	|    ##|
-   (0,0)+----##+
-	|    ##|
-	|   ###|
-	|####  |
-	+------+
-(xmin,ymin)	(xmax,ymin)
+      (xmin,ymax)      (xmax,ymax)
+                +------+
+                |    ##|
+                |    ##|
+                |      |
+                |  ####|
+                |    ##|
+                |    ##|
+                |    ##|
+                |    ##|
+                |    ##|
+                |    ##|
+           (0,0)+----##+
+                |    ##|
+                |   ###|
+                |####  |
+                +------+
+      (xmin,ymin)      (xmax,ymin)
 
-	Note that any of the values can be negative.  Normally, the
+Note that any of the values can be negative.  Normally, the
 data will be returned as a WBFixed, but there is an optional flag
 which may be passed, indicating the data should be rounded and
 returned as a word.
 
 
-DR_FONT_GEN_PATH
+*DR_FONT_GEN_PATH*
 
-	DR_FONT_GEN_PATH is called to return an outline description of
+DR_FONT_GEN_PATH is called to return an outline description of
 a character at a particular pointsize, rotation, etc.  It is used by
 things like the Postscript(tm) printer driver for building Adobe Type
 3 fonts to download to printers when the font is not resident in the
@@ -392,33 +374,33 @@ printer.  For example, Shattuck Avenue (aka Park Avenue) is generally
 not in Postscript printers, and so a Type 3 font would be built and
 downloaded for it.
 
-	This outline description should be comprised of lines, Bezier
+This outline description should be comprised of lines, Bezier
 curves, pen moves, and in some cases, a translation.  Composite
 characters, such as accented letters, can be rendered by rendering the
 accent character, translating, and then rendering the unaccented
 letter.
 
-	The use for generating Postscript fonts is strong enough that
+The use for generating Postscript fonts is strong enough that
 there is a special FGPF_POSTSCRIPT flag which can be passed to the
 function.  The font driver is expected to rotate and scale the
 outlines such that (0,0) is the baseline/starting pen position, and
 the data is sized for a 1000 unit em-square.
 
-	If the FGPF_POSTSCRIPT flag is passed, the font driver is also
+If the FGPF_POSTSCRIPT flag is passed, the font driver is also
 expected to emit a comment at the start of the graphics string which
 contains information for the Postscript "setcachedevice" command.
 This information is the pen width and bounding box information, in the
 order: width(x),width(y),ll(x),ll(y),ur(x),ur(y).
 
 
-DR_FONT_GEN_IN_REGION
+*DR_FONT_GEN_IN_REGION*
 
-	DR_FONT_GEN_IN_REGION is called to add the definition of a
+DR_FONT_GEN_IN_REGION is called to add the definition of a
 character to a passed RegionPath. It is used by the graphics path code
 for filling and/or creating clip paths that contain text strings &
 characters.
 
-	The outline description of a font is normally comprised of
+The outline description of a font is normally comprised of
 lines, Bezier curves & pen moves. At large point sizes (for the
 Nimbus font driver, above 500 points), this data is "played" into a
 RegionPath, and then handed to the video driver which draws the region
@@ -426,7 +408,7 @@ on the screen. For paths, characters are always generated using regions,
 regardless of point size, and use this routine as the method for
 incorporating text into a path.
 
-	An implementation of this call should be careful to include
+An implementation of this call should be careful to include
 the transformations contained in both the GState & Window (ie. use the
 W_curTMatrix) for generating the font, and the font must be carefully
 drawn into the correct location (GS_penPos in the GState) in the
@@ -435,39 +417,37 @@ code might normally do). Finally, one may not assume that this will
 be the only routine called to add data to the RegionPath, so the
 integrity of RegionPath data must be ensured.
 
-	
-------------------------------------------------------------------------------
-	Debugging Tips
-------------------------------------------------------------------------------
 
-	To assist in debugging font drivers and their interaction with
+### 4.5 Debugging Tips
+
+To assist in debugging font drivers and their interaction with
 the Font Manager, there are a number of useful TCL commands available:
 
-fonts - print various items about fonts and font drivers in the system
-pfontinfo - print the FontInfo structure for a font
-pfont - print the FontBuf structure for a font and any bitmaps that
-	have been built for it
-pchar - print the bitmap for a character in a font, if it has been
-	built
-pusage - print the usage values for all characters that have been
-	built, and which of them will be discarded next
+* fonts - print various items about fonts and font drivers in the system
+* pfontinfo - print the FontInfo structure for a font
+* pfont - print the FontBuf structure for a font and any bitmaps that
+        have been built for it
+* pchar - print the bitmap for a character in a font, if it has been
+        built
+* pusage - print the usage values for all characters that have been
+        built, and which of them will be discarded next
 
 
 A typical series of commands might be something like:
 
-(geos:0) 1 => fonts -d			;show the available font drivers
-(geos:0) 2 => fonts -a			;show the available fonts
-(geos:0) 3 => pfontinfo FONT_URW_ROMAN	;show FontInfo for URW Roman
+    (geos:0) 1 => fonts -d                      ;show the available font drivers
+    (geos:0) 2 => fonts -a                      ;show the available fonts
+    (geos:0) 3 => pfontinfo FONT_URW_ROMAN      ;show FontInfo for URW Roman
 
-	<...call GEN_WIDTHS here...>	;now we've got a FontBuf...
+        <...call GEN_WIDTHS here...>            ;now we've got a FontBuf...
 
-(geos:0) 4 => fonts -u FONT_URW_ROMAN	;show sizes of URW Roman in use
-(geos:0) 5 => pfont ^h1ab0h		;print the FontBuf for a font
+    (geos:0) 4 => fonts -u FONT_URW_ROMAN       ;show sizes of URW Roman in use
+    (geos:0) 5 => pfont ^h1ab0h                 ;print the FontBuf for a font
 
-	<...call GEN_CHAR here...>	;now we've got a bitmap...
+        <...call GEN_CHAR here...>              ;now we've got a bitmap...
 
-(geos:0) 6 => pchar C_CAP_A ^h1ab0h	;print the bitmap for 'A'
+     (geos:0) 6 => pchar C_CAP_A ^h1ab0h        ;print the bitmap for 'A'
 
-	<...call GEN_CHAR here...>	;now we've got two bitmaps...
+        <...call GEN_CHAR here...>              ;now we've got two bitmaps...
 
-(geos:0) 7 => pusage ^h1ab0h		;print the LRU information
+     (geos:0) 7 => pusage ^h1ab0h               ;print the LRU information

--- a/TechDocs/Markdown/ddk.md
+++ b/TechDocs/Markdown/ddk.md
@@ -25,3 +25,10 @@
     [3.2 PCMCIA Library Functions](Ddk/ddkpcmcia.md#32-PCMCIA-Library-Functions)  
     [3.3 CardServices Functions](Ddk/ddkpcmcia.md#33-CardServices-Functions)  
     [3.4 CardServices Events](Ddk/ddkpcmcia.md#34-CardServices-Events)  
+
+**[4 Font Driver](Ddk/ddkfont.md#4-font-driver)**   
+    [4.1 Overview](Ddk/ddkfont.md#41-Overview)   
+    [4.2 Initialization Routines](Ddk/ddkfont.md#42-Initialization-Routines)   
+    [4.3 Data Routines](Ddk/ddkfont.md#43-Data-Routines)   
+    [4.4 Metrics Routines](Ddk/ddkfont.md#44-Metrics-Routines)   
+    [4.5 Debugging Tips](Ddk/ddkfont.md#45-Debugging-Tips)   


### PR DESCRIPTION
Here is a first MR to show what I am working on at the moment, and how I think that persistant opening of font files could work.

- The key change is that TrueTypeVars is no longer discardable and gets zero-initialized in `ttinit.c` (to make sure it is realloc'ed to the correct size).
- I have re-added a file `ttadapter.c` as a (temporary?) home for the functions to switch typefaces. Ultimately, they should follow a lock/unlock/free paradigm to reduce heap usage, but at the moment unlocking does nothing, since all pointers to font resources are fixed.
- Along the way, I have moved the font readme file by Gene into the "DDK" section of the docs and reformatted it for markdown.
- I am just looking at optimizing calls between resources (`ProcCallFixedOrMoveable` and `ResourceCallInt`) based on profiling. I already have some simplifications for `ttraster.c` coming up.

Still to do:
- Free a typeface when closing the driver or unloading a font (right now, the font file and allocated memory are leaked). This does not really happen in practice, but it may be necessary to avoid problems during shutdown.
- Look at inter-resource calls and see if some frequent "long" function calls can be made more efficient.